### PR TITLE
Allow hyphens in attribute names

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -64,7 +64,7 @@ CodeMirror.defineSimpleMode('selectors', {
         { regex: /(\.|\#){1}[a-zA-Z0-9\-]+/, token: 'variable-1' }, // id or class
         { regex: /[a-zA-Z0-9]+/, token: 'variable-1' }, // element
         { regex: /:[0-9a-z\-\(\)]+/, token: 'variable-2' }, // pseudoselector
-        { regex: /\[[0-9a-z]+\]/, token: 'operator' }, // attribute selector
+        { regex: /\[[0-9a-z\-]+\]/, token: 'operator' }, // attribute selector
         { regex: /\/\/.*/, token: 'comment', sol: true }
     ]
 });

--- a/src/popup.js
+++ b/src/popup.js
@@ -63,8 +63,8 @@ CodeMirror.defineSimpleMode('selectors', {
     start: [
         { regex: /(\.|\#){1}[a-zA-Z0-9\-]+/, token: 'variable-1' }, // id or class
         { regex: /[a-zA-Z0-9]+/, token: 'variable-1' }, // element
-        { regex: /:[0-9a-z\-\(\)]+/, token: 'variable-2' }, // pseudoselector
-        { regex: /\[[0-9a-z\-]+\]/, token: 'operator' }, // attribute selector
+        { regex: /:[a-zA-Z0-9\-\(\)]+/, token: 'variable-2' }, // pseudoselector
+        { regex: /\[[a-zA-Z0-9\-]+\]/, token: 'operator' }, // attribute selector
         { regex: /\/\/.*/, token: 'comment', sol: true }
     ]
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,7 +3,7 @@
 module.exports = {
     extractAttributeFromSelector(selector) {
         try {
-            return selector.match(/\[([a-z\-]+)\]/)[1];
+            return selector.match(/\[([a-zA-Z0-9\-]+)\]/)[1];
         }
         catch(e) {
             throw new Error('Error while parsing attribute from selector '  + selector);

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,7 +3,7 @@
 module.exports = {
     extractAttributeFromSelector(selector) {
         try {
-            return selector.match(/\[([a-z]+)\]/)[1];
+            return selector.match(/\[([a-z\-]+)\]/)[1];
         }
         catch(e) {
             throw new Error('Error while parsing attribute from selector '  + selector);


### PR DESCRIPTION
This pull request fixes a bug in which the extension wouldn't recognize attributes that contain hyphen characters in their names. This is a bug because hyphens are common in attribute names throughout the web.

For example, the extension would not replace text within the following `data-foo` attribute because of the `-` character in the attribute name:
```
<div data-foo="bar">
```
It would also not highlight the attribute name in orange when you entered any of the following selectors in the popup window:
```
div[data-foo]
[data-foo]
```

This pull request fixes that so `-` is now a valid character and you can select attributes with the above selectors.